### PR TITLE
Fix onnxruntime load error for newest onnxruntime

### DIFF
--- a/scripts/export_onnx_model.py
+++ b/scripts/export_onnx_model.py
@@ -165,7 +165,9 @@ def run_export(
 
     if onnxruntime_exists:
         ort_inputs = {k: to_numpy(v) for k, v in dummy_inputs.items()}
-        ort_session = onnxruntime.InferenceSession(output)
+        # set cpu provider default
+        providers = ['CPUExecutionProvider']
+        ort_session = onnxruntime.InferenceSession(output, providers=providers)
         _ = ort_session.run(None, ort_inputs)
         print("Model has successfully been run with ONNXRuntime.")
 


### PR DESCRIPTION
Here is an error about onnxruntime in 1.13.1:
``` shell
Loading model...
Exporing onnx model to workdir/sam_vit_b_01ec64.onnx...
Traceback (most recent call last):
  File "scripts/export_onnx_model.py", line 179, in <module>
    run_export(
  File "scripts/export_onnx_model.py", line 168, in run_export
    ort_session = onnxruntime.InferenceSession(output)
  File "/home/ubuntu/miniconda3/envs/torch/lib/python3.8/site-packages/onnxruntime/capi/onnxruntime_inference_collection.py", line 360, in __init__
    self._create_inference_session(providers, provider_options, disabled_optimizers)
  File "/home/ubuntu/miniconda3/envs/torch/lib/python3.8/site-packages/onnxruntime/capi/onnxruntime_inference_collection.py", line 388, in _create_inference_session
    raise ValueError(
ValueError: This ORT build has ['TensorrtExecutionProvider', 'CUDAExecutionProvider', 'CPUExecutionProvider'] enabled. Since ORT 1.9, you are required to explicitly set the providers parameter when instantiating InferenceSession. For example, onnxruntime.InferenceSession(..., providers=['TensorrtExecutionProvider', 'CUDAExecutionProvider', 'CPUExecutionProvider'], ...)
```
Maybe we should specify providers.