### PR TITLE
Support onnx-simplify

### DIFF
--- a/scripts/export_onnx_model.py
+++ b/scripts/export_onnx_model.py
@@ -11,7 +11,6 @@ from segment_anything.utils.onnx import SamOnnxModel
 
 import argparse
 import warnings
-from io import BytesIO
 
 try:
     import onnxruntime  # type: ignore

--- a/scripts/export_onnx_model.py
+++ b/scripts/export_onnx_model.py
@@ -21,7 +21,7 @@ except ImportError:
     onnxruntime_exists = False
 
 try:
-    import onnx
+    import onnx  # type: ignore
     import onnxsim  # type: ignore
 
     onnxsim_exists = True

--- a/scripts/export_onnx_model.py
+++ b/scripts/export_onnx_model.py
@@ -110,14 +110,14 @@ parser.add_argument(
 
 
 def run_export(
-        model_type: str,
-        checkpoint: str,
-        output: str,
-        opset: int,
-        return_single_mask: bool,
-        gelu_approximate: bool = False,
-        use_stability_score: bool = False,
-        return_extra_metrics=False,
+    model_type: str,
+    checkpoint: str,
+    output: str,
+    opset: int,
+    return_single_mask: bool,
+    gelu_approximate: bool = False,
+    use_stability_score: bool = False,
+    return_extra_metrics=False,
 ):
     print("Loading model...")
     if model_type == "vit_b":


### PR DESCRIPTION
Simplify onnx model with [onnx-simplify](https://github.com/daquexian/onnx-simplifier).
Usage:
``` shell
python scripts/export_onnx_model.py \
  --checkpoint weights/sam_vit_b_01ec64.pth \
  --output workdir/sam_vit_b_01ec64.onnx \
  --model-type vit_b \
  --simplify
```