### PR TITLE
Update README.md onnx export reqs

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ python scripts/export_onnx_model.py --checkpoint <path/to/checkpoint> --output <
 
 See the [example notebook](https://github.com/facebookresearch/segment-anything/blob/main/notebooks/onnx_model_example.ipynb) for details on how to combine image preprocessing via SAM's backbone with mask prediction using the ONNX model. It is recommended to use the latest stable version of PyTorch for ONNX export.
 
+**NOTE:** ONNX export requires `pytorch>=2.0` to run
+
 ## <a name="Models"></a>Model Checkpoints
 
 Three model versions of the model are available with different backbone sizes. These models can be instantiated by running 


### PR DESCRIPTION
The ONNX export function in the [script](https://github.com/facebookresearch/segment-anything/blob/main/scripts/export_onnx_model.py#L54) and [notebook](https://github.com/facebookresearch/segment-anything/blob/main/notebooks/onnx_model_example.ipynb) uses opset version 17 which requires `pytorch>=2.0`, while the current README states that only `pytorch>=1.7` is required.


README has been updated to reflect this requirement

Issue: #18 