### PR TITLE
Move batched NMS indices to correct device (closes #17)

### DIFF
--- a/segment_anything/automatic_mask_generator.py
+++ b/segment_anything/automatic_mask_generator.py
@@ -214,7 +214,7 @@ class SamAutomaticMaskGenerator:
             keep_by_nms = batched_nms(
                 data["boxes"].float(),
                 scores,
-                torch.zeros(len(data["boxes"])),  # categories
+                torch.zeros_like(data["boxes"][:,0]),  # categories
                 iou_threshold=self.crop_nms_thresh,
             )
             data.filter(keep_by_nms)
@@ -251,7 +251,7 @@ class SamAutomaticMaskGenerator:
         keep_by_nms = batched_nms(
             data["boxes"].float(),
             data["iou_preds"],
-            torch.zeros(len(data["boxes"])),  # categories
+            torch.zeros_like(data["boxes"][:,0]),  # categories
             iou_threshold=self.box_nms_thresh,
         )
         data.filter(keep_by_nms)

--- a/segment_anything/automatic_mask_generator.py
+++ b/segment_anything/automatic_mask_generator.py
@@ -357,7 +357,7 @@ class SamAutomaticMaskGenerator:
         keep_by_nms = batched_nms(
             boxes.float(),
             torch.as_tensor(scores),
-            torch.zeros(len(boxes)),  # categories
+            torch.zeros_like(boxes[:,0]),  # categories
             iou_threshold=nms_thresh,
         )
 


### PR DESCRIPTION
As described in:

- #17 

The following edit to line 254:

```diff
-                torch.zeros(len(data["boxes"])),  # categories
+                torch.zeros_like(data["boxes"][:,0]),  # categories
```

resolves the following error when running on GPU:

```
RuntimeError: indices should be either on cpu or on the same device as the indexed tensor (cpu)
```

which arises from letting torch choose a default device for the zero vector (it chooses CPU).

Here I also proactively fix what is sure to be the same bug on lines 217 and 360.