### PR TITLE
Fix baking original input size values to ONNX graph

### DIFF
--- a/segment_anything/utils/onnx.py
+++ b/segment_anything/utils/onnx.py
@@ -81,8 +81,8 @@ class SamOnnxModel(nn.Module):
             align_corners=False,
         )
 
-        prepadded_size = self.resize_longest_image_size(orig_im_size, self.img_size)
-        masks = masks[..., : int(prepadded_size[0]), : int(prepadded_size[1])]
+        prepadded_size = self.resize_longest_image_size(orig_im_size, self.img_size).to(torch.int64)
+        masks = masks[..., : prepadded_size[0], : prepadded_size[1]]
 
         orig_im_size = orig_im_size.to(torch.int64)
         h, w = orig_im_size[0], orig_im_size[1]


### PR DESCRIPTION
Fix break in computation graph due to typecast to python `int` instead of torch type. This causes image dimensions to not match up properly.

See issue #56 