### PR TITLE
Add sizes of checkpoint files to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,9 +89,9 @@ sam = sam_model_registry["<name>"](checkpoint="<path/to/checkpoint>")
 ```
 Click the links below to download the checkpoint for the corresponding model name. The default model in bold can also be instantiated with `build_sam`, as in the examples in [Getting Started](#getting-started).
 
-* **`default` or `vit_h`: [ViT-H SAM model.](https://dl.fbaipublicfiles.com/segment_anything/sam_vit_h_4b8939.pth)**
-* `vit_l`: [ViT-L SAM model.](https://dl.fbaipublicfiles.com/segment_anything/sam_vit_l_0b3195.pth)
-* `vit_b`: [ViT-B SAM model.](https://dl.fbaipublicfiles.com/segment_anything/sam_vit_b_01ec64.pth)
+* **`default` or `vit_h`: [ViT-H SAM model.](https://dl.fbaipublicfiles.com/segment_anything/sam_vit_h_4b8939.pth)** (2.4 GB)
+* `vit_l`: [ViT-L SAM model.](https://dl.fbaipublicfiles.com/segment_anything/sam_vit_l_0b3195.pth) (1.2 GB)
+* `vit_b`: [ViT-B SAM model.](https://dl.fbaipublicfiles.com/segment_anything/sam_vit_b_01ec64.pth) (358 MB)
 
 ## License
 The model is licensed under the [Apache 2.0 license](LICENSE).


### PR DESCRIPTION
Since the links go directly to the files, it would be helpful to know how large they are prior to starting a download (for those on connection/storage/memory limitations, or otherwise)