### PR TITLE
Navigate up a directory level to fix bug importing from segment_anything

### DIFF
--- a/scripts/amg.py
+++ b/scripts/amg.py
@@ -6,6 +6,8 @@
 
 import cv2  # type: ignore
 
+import sys
+sys.path.append('../') 
 from segment_anything import SamAutomaticMaskGenerator, sam_model_registry
 
 import argparse


### PR DESCRIPTION
Currently, if you run this script as specified in README.md, line 8 will throw ModuleNotFoundError: No module named 'segment_anything'. Currently, the only way to fix this is to either move amg.py up a directory, or add these two lines to it. This is because __init__.py is in segment_anything, i.e. it is only accessible from the main dir. This should also make relative file locations passed into the script be read to/written from with respect to the main directory, not scripts/.