### PR TITLE
fix parameter name

### DIFF
--- a/notebooks/onnx_model_example.ipynb
+++ b/notebooks/onnx_model_example.ipynb
@@ -72,7 +72,7 @@
    "id": "109a5cc2",
    "metadata": {},
    "source": [
-    "If running locally using jupyter, first install `segment_anything` in your environment using the [installation instructions](https://github.com/facebookresearch/segment-anything#installation) in the repository. The latest stable versions of PyTorch and ONNX are recommended for this notebook. If running from Google Colab, set `using_collab=True` below and run the cell. In Colab, be sure to select 'GPU' under 'Edit'->'Notebook Settings'->'Hardware accelerator'."
+    "If running locally using jupyter, first install `segment_anything` in your environment using the [installation instructions](https://github.com/facebookresearch/segment-anything#installation) in the repository. The latest stable versions of PyTorch and ONNX are recommended for this notebook. If running from Google Colab, set `using_colab=True` below and run the cell. In Colab, be sure to select 'GPU' under 'Edit'->'Notebook Settings'->'Hardware accelerator'."
    ]
   },
   {


### PR DESCRIPTION
"using_collab" does not appear in subsequent text, replacing with "using_colab"