### PR TITLE
Change the value of verbose to true.

### DIFF
--- a/scripts/export_onnx_model.py
+++ b/scripts/export_onnx_model.py
@@ -155,7 +155,7 @@ def run_export(
                 tuple(dummy_inputs.values()),
                 f,
                 export_params=True,
-                verbose=False,
+                verbose=True,
                 opset_version=opset,
                 do_constant_folding=True,
                 input_names=list(dummy_inputs.keys()),


### PR DESCRIPTION
The verbose parameter is set to False, which means that no output is generated during the export process, making it harder to debug export errors.Can be set it to True to print out some useful information during the export process, such as output nodes, intermediate nodes, and output shapes.
