### PR TITLE
Update return type hint of predict function

### DIFF
--- a/segment_anything/predictor.py
+++ b/segment_anything/predictor.py
@@ -97,7 +97,7 @@ class SamPredictor:
         mask_input: Optional[np.ndarray] = None,
         multimask_output: bool = True,
         return_logits: bool = False,
-    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    ) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
         """
         Predict masks for the given input prompts, using the currently set image.
 


### PR DESCRIPTION
This PR updates the return type hint of the `predict` function to reflect the actual return types. The return type hint has been changed from `torch.Tensor` to `np.ndarray` for better type consistency and readability.