### PR TITLE
Added changes for MPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ The **Segment Anything Model (SAM)** produces high quality object masks from inp
 
 The code requires `python>=3.8`, as well as `pytorch>=1.7` and `torchvision>=0.8`. Please follow the instructions [here](https://pytorch.org/get-started/locally/) to install both PyTorch and TorchVision dependencies. Installing both PyTorch and TorchVision with CUDA support is strongly recommended.
 
+If you would like to use MPS backend for MacOS devices with Metal programming framework, please install `pytorch>=2.0` and `torchvision>=0.15.0`. Some OPs (in particular, `torchvision::nms`) are still not fully supported by MPS, so please set the environment variable `PYTORCH_ENABLE_MPS_FALLBACK=1` to enable a fallback on CPU in such a case.
+
 Install Segment Anything:
 
 ```

--- a/segment_anything/automatic_mask_generator.py
+++ b/segment_anything/automatic_mask_generator.py
@@ -273,7 +273,9 @@ class SamAutomaticMaskGenerator:
         orig_h, orig_w = orig_size
 
         # Run model on this batch
-        transformed_points = self.predictor.transform.apply_coords(points, im_size)
+        transformed_points = self.predictor.transform.apply_coords(points, im_size).astype(
+            np.float32
+        )
         in_points = torch.as_tensor(transformed_points, device=self.predictor.device)
         in_labels = torch.ones(in_points.shape[0], dtype=torch.int, device=in_points.device)
         masks, iou_preds, _ = self.predictor.predict_torch(

--- a/segment_anything/utils/amg.py
+++ b/segment_anything/utils/amg.py
@@ -320,16 +320,16 @@ def batched_mask_to_box(masks: torch.Tensor) -> torch.Tensor:
     # Get top and bottom edges
     in_height, _ = torch.max(masks, dim=-1)
     in_height_coords = in_height * torch.arange(h, device=in_height.device)[None, :]
-    bottom_edges, _ = torch.max(in_height_coords, dim=-1)
+    bottom_edges, _ = torch.max(in_height_coords.int(), dim=-1)
     in_height_coords = in_height_coords + h * (~in_height)
-    top_edges, _ = torch.min(in_height_coords, dim=-1)
+    top_edges, _ = torch.min(in_height_coords.int(), dim=-1)
 
     # Get left and right edges
     in_width, _ = torch.max(masks, dim=-2)
     in_width_coords = in_width * torch.arange(w, device=in_width.device)[None, :]
-    right_edges, _ = torch.max(in_width_coords, dim=-1)
+    right_edges, _ = torch.max(in_width_coords.int(), dim=-1)
     in_width_coords = in_width_coords + w * (~in_width)
-    left_edges, _ = torch.min(in_width_coords, dim=-1)
+    left_edges, _ = torch.min(in_width_coords.int(), dim=-1)
 
     # If the mask is empty the right edge will be to the left of the left edge.
     # Replace these boxes with [0, 0, 0, 0]


### PR DESCRIPTION
This PR adds support for running the model using the MPS backend on MacOS devices.

As per README, having `pytorch>=2.0` is strongly recommended as it comes with a wider support for various operations on MPS. Also `torchvision::nms` is still not supported by MPS, so one has to use `PYTORCH_ENABLE_MPS_FALLBACK=1` to enable a fallback on CPU.

Tested on M1 using `vit_l` model. Runtime of the amg script:

* with `device=cpu` ~124s
* with `device=mps` ~73s

Resolves the following issues:

https://github.com/facebookresearch/segment-anything/issues/119
https://github.com/facebookresearch/segment-anything/issues/94