### PR TITLE
fix: modify remove_small_regions fuction

### DIFF
--- a/segment_anything/utils/amg.py
+++ b/segment_anything/utils/amg.py
@@ -278,7 +278,7 @@ def remove_small_regions(
     working_mask = (correct_holes ^ mask).astype(np.uint8)
     n_labels, regions, stats, _ = cv2.connectedComponentsWithStats(working_mask, 8)
     sizes = stats[:, -1][1:]  # Row 0 is background label
-    small_regions = [i + 1 for i, s in enumerate(sizes) if s < area_thresh]
+    small_regions = [i + 1 for i, s in enumerate(sizes) if s > area_thresh]
     if len(small_regions) == 0:
         return mask, False
     fill_labels = [0] + small_regions


### PR DESCRIPTION
min_mask_region_area that parameter of SamAutomaticMaskGenerator does not work. 

Even though I increased the minimum size of the mask, there was a problem that the number of masks generated did not change. 
As I checked, it was an issue caused by the wrong direction of inequality inside the function, so I correct it and share it.

