### PR TITLE
fix: min_mask_region_area

### DIFF
--- a/segment_anything/utils/amg.py
+++ b/segment_anything/utils/amg.py
@@ -277,7 +277,13 @@ def remove_small_regions(
     correct_holes = mode == "holes"
     working_mask = (correct_holes ^ mask).astype(np.uint8)
     n_labels, regions, stats, _ = cv2.connectedComponentsWithStats(working_mask, 8)
-    sizes = stats[:, -1][1:]  # Row 0 is background label
+    
+    # sizes = stats[:, -1][1:]  # Row 0 is background label
+    
+    sorted_idx = np.argsort(stats[:, -1])[::-1]
+    sorted_a = stats[sorted_idx]
+    sizes = sorted_a[:, -1][1:]
+    
     small_regions = [i + 1 for i, s in enumerate(sizes) if s < area_thresh]
     if len(small_regions) == 0:
         return mask, False


### PR DESCRIPTION
**fix: min_mask_region_area**
This function used to not work. 
<img width="827" alt="스크린샷 2023-04-13 오후 6 39 04" src="https://user-images.githubusercontent.com/66514138/231719722-26adc7ac-3a9f-423c-a1f8-87d8c649041a.png">
<img width="862" alt="스크린샷 2023-04-13 오후 6 39 39" src="https://user-images.githubusercontent.com/66514138/231719854-0f837e28-d252-4d3c-ace5-34abf86f5415.png">

masks mean min_mask_region_area = 0
masks2 mean min_mask_region_area = 100

As you can see, there are still areas that are less than 100px.

amg.py
293 lines `sizes = stats[:, -1][1:]` look forward to "Row 0 is background label"
But, it is used to not work, because  it's not sorted, then i fix it
<img width="826" alt="스크린샷 2023-04-13 오후 6 37 04" src="https://user-images.githubusercontent.com/66514138/231719253-9e6e8b44-653d-4ca3-a16c-50ed21a42b16.png">
<img width="857" alt="스크린샷 2023-04-13 오후 6 42 21" src="https://user-images.githubusercontent.com/66514138/231720538-388af64d-d587-4e53-a299-e854f4e4aada.png">

Of course, my code could be wrong too, so again, I'd appreciate a review of this issue.