### PR TITLE
Add python venv to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,9 @@ wheels/
 *.ts
 model_ts*.txt
 
+# python virtual environment
+venv
+
 # onnx models
 *.onnx
 


### PR DESCRIPTION
add venv directory to gitignore to not blow up git if a virtual environment is used for pip installs