### PR TITLE
fixing image_encoder to work with cuda_graphs

### DIFF
--- a/segment_anything/modeling/image_encoder.py
+++ b/segment_anything/modeling/image_encoder.py
@@ -315,8 +315,8 @@ def get_rel_pos(q_size: int, k_size: int, rel_pos: torch.Tensor) -> torch.Tensor
         rel_pos_resized = rel_pos
 
     # Scale the coords with short length if shapes for q and k are different.
-    q_coords = torch.arange(q_size)[:, None] * max(k_size / q_size, 1.0)
-    k_coords = torch.arange(k_size)[None, :] * max(q_size / k_size, 1.0)
+    q_coords = (torch.arange(q_size).to(rel_pos.device)[:, None] * max(k_size / q_size, 1.0))
+    k_coords = (torch.arange(k_size).to(rel_pos.device)[None, :] * max(q_size / k_size, 1.0))
     relative_coords = (q_coords - k_coords) + (k_size - 1) * max(q_size / k_size, 1.0)
 
     return rel_pos_resized[relative_coords.long()]

--- a/segment_anything/modeling/image_encoder.py
+++ b/segment_anything/modeling/image_encoder.py
@@ -315,8 +315,8 @@ def get_rel_pos(q_size: int, k_size: int, rel_pos: torch.Tensor) -> torch.Tensor
         rel_pos_resized = rel_pos
 
     # Scale the coords with short length if shapes for q and k are different.
-    q_coords = (torch.arange(q_size).to(rel_pos.device)[:, None] * max(k_size / q_size, 1.0))
-    k_coords = (torch.arange(k_size).to(rel_pos.device)[None, :] * max(q_size / k_size, 1.0))
+    q_coords = (torch.arange(q_size, device=rel_pos.device)[:, None] * max(k_size / q_size, 1.0))
+    k_coords = (torch.arange(k_size, device=rel_pos.device)[None, :] * max(q_size / k_size, 1.0))
     relative_coords = (q_coords - k_coords) + (k_size - 1) * max(q_size / k_size, 1.0)
 
     return rel_pos_resized[relative_coords.long()]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #393

Summary: the combination of tensors on multiple devices in get_rel_pos
was preventing cuda graphs from correctly optimizing things

Test Plan:

Reviewers:

Subscribers:

Tasks:

Tags: