### PR TITLE
Update README.md with checkpoint sizes

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,9 +97,9 @@ sam = sam_model_registry["<model_type>"](checkpoint="<path/to/checkpoint>")
 
 Click the links below to download the checkpoint for the corresponding model type.
 
-- **`default` or `vit_h`: [ViT-H SAM model.](https://dl.fbaipublicfiles.com/segment_anything/sam_vit_h_4b8939.pth)**
-- `vit_l`: [ViT-L SAM model.](https://dl.fbaipublicfiles.com/segment_anything/sam_vit_l_0b3195.pth)
-- `vit_b`: [ViT-B SAM model.](https://dl.fbaipublicfiles.com/segment_anything/sam_vit_b_01ec64.pth)
+ **`default` or `vit_h`: [ViT-H SAM model.](https://dl.fbaipublicfiles.com/segment_anything/sam_vit_h_4b8939.pth)** (2.4 GB)
+* `vit_l`: [ViT-L SAM model.](https://dl.fbaipublicfiles.com/segment_anything/sam_vit_l_0b3195.pth) (1.2 GB)
+* `vit_b`: [ViT-B SAM model.](https://dl.fbaipublicfiles.com/segment_anything/sam_vit_b_01ec64.pth) (358 MB)
 
 ## Dataset
 


### PR DESCRIPTION
Large sizes are linked without file sizes, which makes it difficult to select one.