### PR TITLE
Updated amg.py to allow batching of large mask sets and avoid over-sized torch.nonzero() calls

### DIFF
--- a/segment_anything/automatic_mask_generator.py
+++ b/segment_anything/automatic_mask_generator.py
@@ -161,6 +161,8 @@ class SamAutomaticMaskGenerator:
 
         # Generate masks
         mask_data = self._generate_masks(image)
+        if mask_data is None:
+            return None
 
         # Filter small disconnected regions and holes in masks
         if self.min_mask_region_area > 0:
@@ -204,13 +206,13 @@ class SamAutomaticMaskGenerator:
         data = MaskData()
         for crop_box, layer_idx in zip(crop_boxes, layer_idxs):
             crop_data = self._process_crop(image, crop_box, layer_idx, orig_size)
+            
             data.cat(crop_data)
 
         if data["crop_boxes"] is None or data["crop_boxes"].numel() == 0:
-            print("No valid crop boxes found. Skipping processing.")
-            return MaskData()
-        else:
-            print(data["crop_boxes"].shape)
+            # No masks were found in all the little crops
+            return None
+        
 
         # Remove duplicate masks between crops
         if len(crop_boxes) > 1:

--- a/segment_anything/automatic_mask_generator.py
+++ b/segment_anything/automatic_mask_generator.py
@@ -206,6 +206,12 @@ class SamAutomaticMaskGenerator:
             crop_data = self._process_crop(image, crop_box, layer_idx, orig_size)
             data.cat(crop_data)
 
+        if data["crop_boxes"] is None or data["crop_boxes"].numel() == 0:
+            print("No valid crop boxes found. Skipping processing.")
+            return MaskData()
+        else:
+            print(data["crop_boxes"].shape)
+
         # Remove duplicate masks between crops
         if len(crop_boxes) > 1:
             # Prefer masks from smaller crops

--- a/segment_anything/automatic_mask_generator.py
+++ b/segment_anything/automatic_mask_generator.py
@@ -31,6 +31,7 @@ from .utils.amg import (
     uncrop_points,
 )
 
+import cv2, time
 
 class SamAutomaticMaskGenerator:
     def __init__(
@@ -211,6 +212,8 @@ class SamAutomaticMaskGenerator:
 
         if data["crop_boxes"] is None or data["crop_boxes"].numel() == 0:
             # No masks were found in all the little crops
+            # saving problem image
+            cv2.imwrite(f"errorimg_{time.time()}.png",image)
             return None
         
 

--- a/segment_anything/utils/amg.py
+++ b/segment_anything/utils/amg.py
@@ -122,11 +122,11 @@ def mask_to_rle_pytorch(tensor: torch.Tensor) -> List[Dict[str, Any]]:
     total_elements = b * w_h
     print(f"Total number of elements appears to be: {total_elements}")
     # Maximum allowable elements in one chunk
-    max_elements_per_chunk = 2**8 - 1
+    max_elements_per_chunk = 2**31 - 1
     print(f"We're guessing that INT_MAX is: {max_elements_per_chunk}")
 
     if total_elements < max_elements_per_chunk:
-        change_indices = diff.nonzero() # the tensor is < 8 bit? so we find the change indices in a single torch call.
+        change_indices = diff.nonzero() # the tensor is < 32 bit so we find the change indices in a single torch call.
     else:
         # Calculate the number of chunks needed
         num_chunks = total_elements // max_elements_per_chunk

--- a/segment_anything/utils/amg.py
+++ b/segment_anything/utils/amg.py
@@ -7,7 +7,7 @@
 import numpy as np
 import torch
 
-import math, sys
+import math
 from copy import deepcopy
 from itertools import product
 from typing import Any, Dict, Generator, ItemsView, List, Tuple
@@ -116,16 +116,19 @@ def mask_to_rle_pytorch(tensor: torch.Tensor) -> List[Dict[str, Any]]:
     # Compute change indices
     diff = tensor[:, 1:] ^ tensor[:, :-1]
 
-    # the torch function nonzero() only works up to INT_MAX tensor elements, so we first test if we have more than that.
+    # the torch function nonzero() only works up to INT_MAX tensor elements
+    # We first test if we have more than that:
     # Total elements in the tensor
     b, w_h = diff.shape
     total_elements = b * w_h
-    
+
     # Maximum allowable elements in one chunk - as torch is using 32 bit integers for this function
-    max_elements_per_chunk = 2**31 - 1 
+    max_elements_per_chunk = 2**31 - 1
 
     if total_elements < max_elements_per_chunk:
-        change_indices = diff.nonzero() # the tensor is < 32 bit so we find the change indices in a single torch call.
+        change_indices = (
+            diff.nonzero()
+        )  # the tensor is < 32 bit so we find the change indices in a single torch call.
     else:
         # Calculate the number of chunks needed
         num_chunks = total_elements // max_elements_per_chunk
@@ -136,27 +139,27 @@ def mask_to_rle_pytorch(tensor: torch.Tensor) -> List[Dict[str, Any]]:
         chunk_size = b // num_chunks
         if b % num_chunks != 0:
             chunk_size += 1
-        
+
         # List to store the results from each chunk
         all_indices = []
 
         # Loop through the diff tensor in chunks
         for i in range(num_chunks):
             start = i * chunk_size
-            end = min((i+1) * chunk_size, b)
+            end = min((i + 1) * chunk_size, b)
             chunk = diff[start:end, :]
-            
+
             # Get non-zero indices for the current chunk
             indices = chunk.nonzero()
-            
+
             # Adjust the row indices to the original tensor
             indices[:, 0] += start
-            
+
             all_indices.append(indices)
 
         # Concatenate all the results
         change_indices = torch.cat(all_indices, dim=0)
-    
+
     # Encode run length
     out = []
     for i in range(b):

--- a/segment_anything/utils/amg.py
+++ b/segment_anything/utils/amg.py
@@ -122,11 +122,11 @@ def mask_to_rle_pytorch(tensor: torch.Tensor) -> List[Dict[str, Any]]:
     total_elements = b * w_h
     print(f"Total number of elements appears to be: {total_elements}")
     # Maximum allowable elements in one chunk
-    max_elements_per_chunk = 2**15 - 1
+    max_elements_per_chunk = 2**8 - 1
     print(f"We're guessing that INT_MAX is: {max_elements_per_chunk}")
 
     if total_elements < max_elements_per_chunk:
-        change_indices = diff.nonzero() # the tensor is "small" so we find the change indices in a single torch call.
+        change_indices = diff.nonzero() # the tensor is < 8 bit? so we find the change indices in a single torch call.
     else:
         # Calculate the number of chunks needed
         num_chunks = total_elements // max_elements_per_chunk

--- a/segment_anything/utils/amg.py
+++ b/segment_anything/utils/amg.py
@@ -122,7 +122,7 @@ def mask_to_rle_pytorch(tensor: torch.Tensor) -> List[Dict[str, Any]]:
     total_elements = b * w_h
     print(f"Total number of elements appears to be: {total_elements}")
     # Maximum allowable elements in one chunk
-    max_elements_per_chunk = sys.maxsize
+    max_elements_per_chunk = 2**31 - 1
     print(f"We're guessing that INT_MAX is: {max_elements_per_chunk}")
 
     if total_elements < max_elements_per_chunk:

--- a/segment_anything/utils/amg.py
+++ b/segment_anything/utils/amg.py
@@ -122,7 +122,7 @@ def mask_to_rle_pytorch(tensor: torch.Tensor) -> List[Dict[str, Any]]:
     total_elements = b * w_h
     print(f"Total number of elements appears to be: {total_elements}")
     # Maximum allowable elements in one chunk
-    max_elements_per_chunk = 2**31 - 1
+    max_elements_per_chunk = 2**15 - 1
     print(f"We're guessing that INT_MAX is: {max_elements_per_chunk}")
 
     if total_elements < max_elements_per_chunk:

--- a/segment_anything/utils/amg.py
+++ b/segment_anything/utils/amg.py
@@ -120,8 +120,11 @@ def mask_to_rle_pytorch(tensor: torch.Tensor) -> List[Dict[str, Any]]:
     # Total elements in the tensor
     b, w_h = diff.shape
     total_elements = b * w_h
+    print(f"Total number of elements appears to be: {total_elements}")
     # Maximum allowable elements in one chunk
     max_elements_per_chunk = sys.maxsize
+    print(f"We're guessing that INT_MAX is: {max_elements_per_chunk}")
+
     if total_elements < max_elements_per_chunk:
         change_indices = diff.nonzero() # the tensor is "small" so we find the change indices in a single torch call.
     else:

--- a/segment_anything/utils/amg.py
+++ b/segment_anything/utils/amg.py
@@ -120,10 +120,9 @@ def mask_to_rle_pytorch(tensor: torch.Tensor) -> List[Dict[str, Any]]:
     # Total elements in the tensor
     b, w_h = diff.shape
     total_elements = b * w_h
-    print(f"Total number of elements appears to be: {total_elements}")
-    # Maximum allowable elements in one chunk
-    max_elements_per_chunk = 2**31 - 1
-    print(f"We're guessing that INT_MAX is: {max_elements_per_chunk}")
+    
+    # Maximum allowable elements in one chunk - as torch is using 32 bit integers for this function
+    max_elements_per_chunk = 2**31 - 1 
 
     if total_elements < max_elements_per_chunk:
         change_indices = diff.nonzero() # the tensor is < 32 bit so we find the change indices in a single torch call.


### PR DESCRIPTION
Fixes issue where `Tensor.nonzero` would fail on GPU for tensors containing more than `INT_MAX` elements.

Changes made:
- Implemented a chunking mechanism to handle tensors in manageable sizes.
- Each chunk's size is safely under the `INT_MAX` limit.
- Non-zero indices from each chunk are concatenated to produce the final result.

This resolves the issue reported in #554 which correlates with the PyTorch issue [pytorch/pytorch#51871](https://github.com/pytorch/pytorch/issues/51871).
