### PR TITLE
Speedup patch embedding by moving coord creation on device

### DIFF
--- a/segment_anything/modeling/image_encoder.py
+++ b/segment_anything/modeling/image_encoder.py
@@ -315,8 +315,8 @@ def get_rel_pos(q_size: int, k_size: int, rel_pos: torch.Tensor) -> torch.Tensor
         rel_pos_resized = rel_pos
 
     # Scale the coords with short length if shapes for q and k are different.
-    q_coords = torch.arange(q_size)[:, None] * max(k_size / q_size, 1.0)
-    k_coords = torch.arange(k_size)[None, :] * max(q_size / k_size, 1.0)
+    q_coords = torch.arange(q_size, device=rel_pos.device)[:, None] * max(k_size / q_size, 1.0)
+    k_coords = torch.arange(k_size, device=rel_pos.device)[None, :] * max(q_size / k_size, 1.0)
     relative_coords = (q_coords - k_coords) + (k_size - 1) * max(q_size / k_size, 1.0)
 
     return rel_pos_resized[relative_coords.long()]


### PR DESCRIPTION
While experimenting with image segmentation and using the `prun` function on `predictor.set_image`, I discovered a significant performance issue in the `get_rel_pos` function.

The problem arises from the lack of device assignment for the tensor containing relative positions, causing unnecessary data transfers when using accelerators like GPUs.

The solution is rather simple: create the coordinate tensor on the same device as the underlying data. 
In my specific case (vit-b, P100 GPU, 128x128 image size), this change reduced the `get_rel_pos` execution time from 197ms to 3ms, cutting down the `predictor.set_image` runtime from 220ms to 20ms.

Given that there's no reason to keep the coordinate tensor creation outside the device, I suggest incorporating this change into the official release for the benefit of all users.