### PR TITLE
Add flexibility to SamAutomaticMaskGenerator

### DIFF
--- a/segment_anything/automatic_mask_generator.py
+++ b/segment_anything/automatic_mask_generator.py
@@ -189,6 +189,7 @@ class SamAutomaticMaskGenerator:
                 "point_coords": [mask_data["points"][idx].tolist()],
                 "stability_score": mask_data["stability_score"][idx].item(),
                 "crop_box": box_xyxy_to_xywh(mask_data["crop_boxes"][idx]).tolist(),
+                "low_res": mask_data["low_res"][idx],
             }
             curr_anns.append(ann)
 
@@ -276,7 +277,7 @@ class SamAutomaticMaskGenerator:
         transformed_points = self.predictor.transform.apply_coords(points, im_size)
         in_points = torch.as_tensor(transformed_points, device=self.predictor.device)
         in_labels = torch.ones(in_points.shape[0], dtype=torch.int, device=in_points.device)
-        masks, iou_preds, _ = self.predictor.predict_torch(
+        masks, iou_preds, low_res = self.predictor.predict_torch(
             in_points[:, None, :],
             in_labels[:, None],
             multimask_output=True,
@@ -288,6 +289,7 @@ class SamAutomaticMaskGenerator:
             masks=masks.flatten(0, 1),
             iou_preds=iou_preds.flatten(0, 1),
             points=torch.as_tensor(points.repeat(masks.shape[1], axis=0)),
+            low_res=low_res.flatten(0, 1),
         )
         del masks
 


### PR DESCRIPTION

### Reason for changes/adaptations
RAM issues when using SamAutomaticMaskGenerator with high resolution images.

### Suggested solution
1. Input downsampled image to the generator. - _implemented by the user in its use case_
1. Return low_res logits for each result - change in this repo
1. Upsample the selected mask. - _implemented by the user in its use case_

### Changes
1. modified SamAutomaticMaskGenerator.generate() method and consecutive methods called in order to return low_res logits