### PR TITLE
[+] add save and load embedding methods in SamPredictor class

### DIFF
--- a/segment_anything/predictor.py
+++ b/segment_anything/predictor.py
@@ -267,3 +267,35 @@ class SamPredictor:
         self.orig_w = None
         self.input_h = None
         self.input_w = None
+  
+    def save_image_embedding(self, path):
+      """
+      Saves the image embedding to a file.
+
+      Args:
+        path (str): The path to save the image embedding.
+
+      Raises:
+        RuntimeError: If an image has not been set with `.set_image()` before saving the embedding.
+      """
+      if not self.is_image_set:
+        raise RuntimeError("An image must be set with .set_image() before saving an embedding.")
+      res = {
+        'original_size': self.original_size,
+        'input_size': self.input_size,
+        'features': self.features.cpu().numpy(),
+        'is_image_set': True,
+      }
+      torch.save(res, path)
+
+    def load_image_embedding(self, path):
+        """
+        Loads the image embedding from the specified path and sets it as an attribute of the object.
+
+        Args:
+          path (str): The path to the image embedding file.
+        """
+        res = torch.load(path, map_location=self.device)
+        for k, v in res.items():
+          setattr(self, k, v)
+        self.features = torch.from_numpy(self.features).to(self.device)


### PR DESCRIPTION
Added save and load functionality for image embeddings in SamPredictor class.

This pull request includes two new methods in the SamPredictor class:

- `save_image_embedding(self, path)`: This method allows saving the image embedding to a specified path. It raises a RuntimeError if an image has not been set with `.set_image()` before saving the embedding.
- `load_image_embedding(self, path)`: This method allows loading the image embedding from a specified path and sets it as an attribute of the object. It uses the `torch` library to load the saved embedding.

