### PR TITLE
Add support for running inferences with bfloat16

### DIFF
--- a/segment_anything/predictor.py
+++ b/segment_anything/predictor.py
@@ -161,8 +161,8 @@ class SamPredictor:
         )
 
         masks_np = masks[0].detach().cpu().numpy()
-        iou_predictions_np = iou_predictions[0].detach().cpu().numpy()
-        low_res_masks_np = low_res_masks[0].detach().cpu().numpy()
+        iou_predictions_np = iou_predictions[0].detach().cpu().to(torch.float32).numpy()
+        low_res_masks_np = low_res_masks[0].detach().cpu().to(torch.float32).numpy()
         return masks_np, iou_predictions_np, low_res_masks_np
 
     @torch.no_grad()


### PR DESCRIPTION
When running an inference with bfloat16, the script crashes within the SamPredictor.predict() function when converting the tensors to numpy arrays. This is caused by numpy's lack of support for bfloat16. 

The PyTorchs.to() function is used to explicitly convert the tensor to float32, which adresses the problem. 