### PR TITLE
Use index_select instead of dynamic slicing for onnx export

### DIFF
--- a/segment_anything/utils/onnx.py
+++ b/segment_anything/utils/onnx.py
@@ -82,7 +82,10 @@ class SamOnnxModel(nn.Module):
         )
 
         prepadded_size = self.resize_longest_image_size(orig_im_size, self.img_size).to(torch.int64)
-        masks = masks[..., : prepadded_size[0], : prepadded_size[1]]  # type: ignore
+        row_indices = torch.arange(prepadded_size[0])
+        col_indices = torch.arange(prepadded_size[1])
+        masks = torch.index_select(masks, dim=2, index=row_indices)
+        masks = torch.index_select(masks, dim=3, index=col_indices)
 
         orig_im_size = orig_im_size.to(torch.int64)
         h, w = orig_im_size[0], orig_im_size[1]


### PR DESCRIPTION
The onnx export hardcoded the image dimensions because it apparently doesn't properly support dynamic slicing.

This fixes an issue with masks not being aligned to the images, see #795.
