### PR TITLE
Fix(notebook): correct typo in onnx_model_example.ipynb

### DIFF
--- a/notebooks/onnx_model_example.ipynb
+++ b/notebooks/onnx_model_example.ipynb
@@ -364,7 +364,7 @@
    "id": "7708ead6",
    "metadata": {},
    "source": [
-    "To use the ONNX model, the image must first be pre-processed using the SAM image encoder. This is a heavier weight process best performed on GPU. SamPredictor can be used as normal, then `.get_image_embedding()` will retreive the intermediate features."
+    "To use the ONNX model, the image must first be pre-processed using the SAM image encoder. This is a heavier weight process best performed on GPU. SamPredictor can be used as normal, then `.get_image_embedding()` will retrieve the intermediate features."
    ]
   },
   {


### PR DESCRIPTION
This PR corrects `retreive` -> `retrieve` within `notebooks/onnx_model_example.ipynb` notebook.