### PR TITLE
Fix division by zero in calculate_stability_score

### DIFF
--- a/segment_anything/utils/amg.py
+++ b/segment_anything/utils/amg.py
@@ -173,7 +173,7 @@ def calculate_stability_score(
         .sum(-1, dtype=torch.int16)
         .sum(-1, dtype=torch.int32)
     )
-    return intersections / unions
+    return intersections / torch.clamp(unions, min=1)
 
 
 def build_point_grid(n_per_side: int) -> np.ndarray:


### PR DESCRIPTION
## Summary

- `calculate_stability_score` in `segment_anything/utils/amg.py` divides `intersections / unions` without guarding against a zero `unions` value. When all mask logits fall below the lower threshold (`mask_threshold - threshold_offset`), the union count is zero, producing `inf` or `nan` stability scores that propagate through downstream filtering and cause unexpected behavior during automatic mask generation.
- Fix: clamp the union denominator to a minimum of 1 via `torch.clamp(unions, min=1)`, so empty masks correctly receive a stability score of 0.0 and are filtered out by the `stability_score_thresh` check.

## Reproduction

When running `SamAutomaticMaskGenerator.generate()` on images where certain point prompts produce mask logits that are all below `mask_threshold - stability_score_offset` (e.g., very low-confidence predictions on blank or adversarial regions), `calculate_stability_score` returns `inf` or `nan`. These values bypass the `stability_score_thresh` filtering (since `nan > threshold` is `False` but `inf > threshold` is `True`), allowing garbage masks through the pipeline.

## Test plan

- [x] Verified the one-line change produces correct behavior: when `unions == 0`, the result is `0 / 1 = 0.0` (mask filtered out), and when `unions > 0`, behavior is unchanged.
- [ ] Run existing tests: `python -m pytest tests/`