### PR TITLE
Fix --crop-overlap-ratio CLI argument type (int -> float)

### DIFF
--- a/scripts/amg.py
+++ b/scripts/amg.py
@@ -126,7 +126,7 @@ amg_settings.add_argument(
 
 amg_settings.add_argument(
     "--crop-overlap-ratio",
-    type=int,
+    type=float,
     default=None,
     help="Larger numbers mean image crops will overlap more.",
 )


### PR DESCRIPTION
## Summary

Fixes #259.

`scripts/amg.py` declares the `--crop-overlap-ratio` CLI flag as `type=int`, but `crop_overlap_ratio` is a **float fraction in [0, 1]** everywhere else:

- `SamAutomaticMaskGenerator.__init__` defaults it to `crop_overlap_ratio: float = 512 / 1500` (~0.341).
- Its docstring documents it as `crop_overlap_ratio (float)`.
- `amg.py` passes `args.crop_overlap_ratio` straight into the generator.

With `type=int`:

1. The documented/intended fractional value is **rejected** by argparse:
   ```
   amg.py: error: argument --crop-overlap-ratio: invalid int value: '0.341'
   ```
2. The only accepted values (integers) are wrong — e.g. `1` makes crops overlap by the full image side, far from the intended ~0.34 fraction.

The other fractional AMG flags (`--pred-iou-thresh`, `--stability-score-thresh`, `--crop-nms-thresh`) are all correctly `type=float`, confirming this is an oversight.

## Fix

```diff
 amg_settings.add_argument(
     "--crop-overlap-ratio",
-    type=int,
+    type=float,
     default=None,
     help="Larger numbers mean image crops will overlap more.",
 )
```

After the change, `--crop-overlap-ratio 0.341` parses to `0.341`, matching the generator's default `512 / 1500`.

(The repo has no Python test suite for `scripts/`, so no test is added; this is a one-line argparse type correction.)
